### PR TITLE
Update CLI parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 3.8 | 3.9 | 3.10 | 3.11](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)](https://www.python.org/downloads)
+[![Python 3.8 | 3.9 | 3.10 | 3.11 | 3.12](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org/downloads)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
@@ -43,17 +43,16 @@ is completely stand-alone and can be invoked directly.
 ### Usage:
 
 ```console
-usage: braghook [-h] [--bragfile BRAGFILE] [--create-config] [--auto-send] [--config CONFIG]
+braghook --help
+usage: braghook [-h] [--send] [--createconfig] [--bragfile BRAGFILE] [--config CONFIG]
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --bragfile BRAGFILE, -b BRAGFILE
-                        The brag file to use
-  --create-config, -C   Create the config file
-  --auto-send, -a       Automatically send the brag
-  --config CONFIG, -c CONFIG
-                        The config file to use
-  ```
+  -h, --help           show this help message and exit
+  --send               Send the brag
+  --createconfig       Create the config file
+  --bragfile BRAGFILE  The brag file to use
+  --config CONFIG      The config file to use
+```
 
 ### Config file:
 

--- a/src/braghook/braghook.py
+++ b/src/braghook/braghook.py
@@ -408,37 +408,28 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     """Parse the arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Send the brag",
+    )
+    parser.add_argument(
+        "--createconfig",
+        action="store_true",
+        help="Create the config file",
+    )
+    parser.add_argument(
         "--bragfile",
-        "-b",
         type=str,
         help="The brag file to use",
         default=None,
     )
     parser.add_argument(
-        "--create-config",
-        "-C",
-        action="store_true",
-        help="Create the config file",
-    )
-    parser.add_argument(
-        "--auto-send",
-        "-a",
-        action="store_true",
-        help="Automatically send the brag",
-    )
-    parser.add_argument(
         "--config",
-        "-c",
         type=str,
         default=DEFAULT_CONFIG_FILE,
         help="The config file to use",
     )
     return parser.parse_args(args)
-
-
-def get_input(prompt: str) -> str:
-    """Get input from the user."""
-    return input(prompt)
 
 
 def send_brags(config: Config, filename: str, content: str) -> None:
@@ -452,24 +443,23 @@ def main(_args: list[str] | None = None) -> int:
     """Run the program."""
     args = parse_args(_args)
 
-    if args.create_config:
+    if args.createconfig:
         create_config()
         return 0
 
     config = load_config(args.config)
     filename = args.bragfile or create_filename(config)
-
     create_if_missing(filename)
 
-    open_editor(config, filename)
+    if args.send:
+        content = read_file_contents(filename)
+        append_weather_to_content(config, content)
 
-    if not args.auto_send and get_input("Send brag? [y/N] ").lower() != "y":
+        send_brags(config, filename, content)
+
         return 0
 
-    content = read_file_contents(filename)
-    append_weather_to_content(config, content)
-
-    send_brags(config, filename, content)
+    open_editor(config, filename)
 
     return 0
 

--- a/src/braghook/braghook.py
+++ b/src/braghook/braghook.py
@@ -234,7 +234,7 @@ def post_brag_to_gist(config: Config, filename: str, content: str) -> None:
     url = config.github_api_url.replace("http://", "").replace("https://", "")
 
     if not config.github_user or not config.github_pat or not config.gist_id:
-        return
+        return None
 
     conn = http.client.HTTPSConnection(url)
     headers = {
@@ -441,6 +441,13 @@ def get_input(prompt: str) -> str:
     return input(prompt)
 
 
+def send_brags(config: Config, filename: str, content: str) -> None:
+    """Send brags to hooks or other targets."""
+    send_message(config, content)
+
+    post_brag_to_gist(config, filename, content)
+
+
 def main(_args: list[str] | None = None) -> int:
     """Run the program."""
     args = parse_args(_args)
@@ -461,8 +468,8 @@ def main(_args: list[str] | None = None) -> int:
 
     content = read_file_contents(filename)
     append_weather_to_content(config, content)
-    send_message(config, content)
-    post_brag_to_gist(config, filename, content)
+
+    send_brags(config, filename, content)
 
     return 0
 

--- a/src/braghook/braghook.py
+++ b/src/braghook/braghook.py
@@ -34,11 +34,11 @@ if TYPE_CHECKING:
 DEFAULT_CONFIG_FILE = "braghook.ini"
 DEFAULT_FILE_TEMPLATE = """### {date}
 
-Write your brag here. Summarize what you did today, what you learned,
- and what you plan to do tomorrow.
+Motivation summary:
 
-- Bullet specific things you did (meetings, tasks, etc.)
-  - Nest details such as links to tasks, commits, or PRs
+Shout outs:
+
+Improvements:
 
 """
 

--- a/tests/braghook_test.py
+++ b/tests/braghook_test.py
@@ -414,29 +414,20 @@ def test_build_msteams_webhook() -> None:
     assert result
 
 
-def test_get_input() -> None:
-    with patch("builtins.input") as mock_input:
-        mock_input.return_value = "y"
-
-        assert braghook.get_input("Test prompt") == "y"
-
-
 def test_parse_args() -> None:
     args = braghook.parse_args(
         [
-            "--config",
-            "tests/braghook.ini",
-            "--bragfile",
-            "tests/brag.md",
-            "--create-config",
-            "--auto-send",
+            "--send",
+            "--createconfig",
+            *("--bragfile", "tests/brag.md"),
+            *("--config", "tests/braghook.ini"),
         ]
     )
 
-    assert args.config == "tests/braghook.ini"
+    assert args.send is True
+    assert args.createconfig is True
     assert args.bragfile == "tests/brag.md"
-    assert args.create_config
-    assert args.auto_send
+    assert args.config == "tests/braghook.ini"
 
 
 def test_send_brags() -> None:
@@ -450,37 +441,32 @@ def test_send_brags() -> None:
     assert mock_post.call_count == 1
 
 
-def test_main() -> None:
+def test_main_send_only() -> None:
     module = "braghook.braghook"
     # Turn black off to make this more readable and easier to maintain
     # fmt: off
     with patch("braghook.braghook.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
-            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
             patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
-        get_input.return_value = "y"
-
         braghook.main(
             [
-                "--config",
-                "tests/bh.ini",
-                "--bragfile",
-                "tests/brag.md",
+                "--send",
+                *("--config", "tests/bh.ini"),
+                *("--bragfile", "tests/brag.md"),
             ]
         )
 
         load_config.assert_called_once_with("tests/bh.ini")
-        open_editor.assert_called_once()
         read_file.assert_called_once()
         create_if_missing.assert_called_once()
         append_weather_to_content.assert_called_once()
-        get_input.assert_called_once()
         send_brags.assert_called_once()
+        open_editor.assert_not_called()
 
 
 def test_main_no_send() -> None:
@@ -490,26 +476,22 @@ def test_main_no_send() -> None:
     with patch(f"{module}.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
-            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
             patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
-        get_input.return_value = "n"
-
         braghook.main(
             [
-                "--config",
-                "tests/braghook.ini",
-                "--bragfile",
-                "tests/brag.md",
+                *("--config", "tests/braghook.ini"),
+                *("--bragfile", "tests/brag.md"),
             ]
         )
 
         load_config.assert_called_once_with("tests/braghook.ini")
         create_if_missing.assert_called_once()
         open_editor.assert_called_once()
+
         read_file.assert_not_called()
         append_weather_to_content.assert_not_called()
         send_brags.assert_not_called()
@@ -524,29 +506,24 @@ def test_main_create_config() -> None:
             patch(f"{module}.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
-            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
             patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
-        get_input.return_value = "y"
-
         braghook.main(
             [
-                "--config",
-                "tests/braghook.ini",
-                "--bragfile",
-                "tests/brag.md",
-                "--create-config",
+                "--createconfig",
+                *("--config", "tests/braghook.ini"),
+                *("--bragfile", "tests/brag.md"),
             ]
         )
 
         create_config.assert_called_once()
+
         load_config.assert_not_called()
         create_if_missing.assert_not_called()
         open_editor.assert_not_called()
-        get_input.assert_not_called()
         read_file.assert_not_called()
         append_weather_to_content.assert_not_called()
         send_brags.assert_not_called()

--- a/tests/braghook_test.py
+++ b/tests/braghook_test.py
@@ -439,6 +439,17 @@ def test_parse_args() -> None:
     assert args.auto_send
 
 
+def test_send_brags() -> None:
+    """Assert expected emitter functions are called."""
+    config = braghook.Config()
+    with patch.object(braghook, "send_message") as mock_send:
+        with patch.object(braghook, "post_brag_to_gist") as mock_post:
+            braghook.send_brags(config, "mock_file", "Mock Content")
+
+    assert mock_send.call_count == 1
+    assert mock_post.call_count == 1
+
+
 def test_main() -> None:
     module = "braghook.braghook"
     # Turn black off to make this more readable and easier to maintain
@@ -446,11 +457,10 @@ def test_main() -> None:
     with patch("braghook.braghook.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
+            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
-            patch(f"{module}.send_message") as send_message, \
-            patch(f"{module}.get_input") as get_input, \
-            patch(f"{module}.post_brag_to_gist") as post_brag:
+            patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
         get_input.return_value = "y"
@@ -469,9 +479,8 @@ def test_main() -> None:
         read_file.assert_called_once()
         create_if_missing.assert_called_once()
         append_weather_to_content.assert_called_once()
-        send_message.assert_called_once()
         get_input.assert_called_once()
-        post_brag.assert_called_once()
+        send_brags.assert_called_once()
 
 
 def test_main_no_send() -> None:
@@ -481,10 +490,10 @@ def test_main_no_send() -> None:
     with patch(f"{module}.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
+            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
-            patch(f"{module}.send_message") as send_message, \
-            patch(f"{module}.get_input") as get_input:
+            patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
         get_input.return_value = "n"
@@ -503,7 +512,7 @@ def test_main_no_send() -> None:
         open_editor.assert_called_once()
         read_file.assert_not_called()
         append_weather_to_content.assert_not_called()
-        send_message.assert_not_called()
+        send_brags.assert_not_called()
 
 
 def test_main_create_config() -> None:
@@ -515,10 +524,10 @@ def test_main_create_config() -> None:
             patch(f"{module}.load_config") as load_config, \
             patch(f"{module}.create_if_missing") as create_if_missing, \
             patch(f"{module}.open_editor") as open_editor, \
+            patch(f"{module}.get_input") as get_input, \
             patch(f"{module}.read_file_contents") as read_file, \
             patch(f"{module}.append_weather_to_content") as append_weather_to_content, \
-            patch(f"{module}.send_message") as send_message, \
-            patch(f"{module}.get_input") as get_input:
+            patch(f"{module}.send_brags") as send_brags:
         # fmt: on
 
         get_input.return_value = "y"
@@ -537,7 +546,7 @@ def test_main_create_config() -> None:
         load_config.assert_not_called()
         create_if_missing.assert_not_called()
         open_editor.assert_not_called()
+        get_input.assert_not_called()
         read_file.assert_not_called()
         append_weather_to_content.assert_not_called()
-        send_message.assert_not_called()
-        get_input.assert_not_called()
+        send_brags.assert_not_called()


### PR DESCRIPTION
Instead of exit input, use a CLI flag `--send` to send brag hooks.