### PR TITLE
pre-commit updates with formatting changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,41 +11,24 @@ repos:
       - id: check-docstring-first
       - id: debug-statements
       - id: mixed-line-ending
-        args:
-          - "--fix=lf"
 
-  # Adds a standard feel to import segments, adds future annotations
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  # Adds a standard feel to import segments
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-      - id: reorder-python-imports
+      - id: isort
         args:
-          - "--py37-plus"
+          - "--force-single-line-imports"
           - "--add-import"
           - "from __future__ import annotations"
-          - "--application-directories"
-          - ".:src"
-
-  # Automatically upgrade syntax to newer versions
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - "--py38-plus"
+          - "--profile"
+          - "black"
 
   # Format code. No, I don't like everything black does either.
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.1.1
     hooks:
       - id: black
-
-  # Format docs.
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black>=23.3.0]
 
   # Flake8 for linting, line-length adjusted to match Black default
   - repo: https://github.com/PyCQA/flake8

--- a/src/braghook/braghook.py
+++ b/src/braghook/braghook.py
@@ -1,6 +1,7 @@
 """
 BragHook.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -13,8 +14,8 @@ import subprocess
 from configparser import ConfigParser
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import Any
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -27,8 +28,7 @@ if TYPE_CHECKING:
             author: str,
             author_icon: str,
             content: str,
-        ) -> dict[str, Any]:
-            ...
+        ) -> dict[str, Any]: ...
 
 
 NEWFILE_NAME = datetime.now().strftime("brag-%Y-%m-%d.md")


### PR DESCRIPTION
black 24.1 formatting changes

Do to conflicts against the format of `black`, the tool `reorder-python-imports` is replaced with `isort`.

Removing `pyupgrade` to reduce tool opinionation further.